### PR TITLE
Fix overlay of zoom controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,9 @@
       overflow: hidden;
       background: #000;
     }
+    #pano {
+      position: relative;
+    }
     #clueBox {
       position: absolute;
       top: 10px;
@@ -30,6 +33,7 @@
       display: flex;
       flex-direction: column;
       gap: 10px;
+      z-index: 10;
     }
     #leftControls { left: 10px; }
     #rightControls { right: 10px; }


### PR DESCRIPTION
## Summary
- ensure `#pano` is positioned for overlay
- raise z-index of control buttons so that zoom buttons receive clicks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851e43900508324876fdf829ee065ae